### PR TITLE
add support for listing cameo members in cards

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -146,6 +146,7 @@ class CardSerializer(MagiSerializer):
     def _postsave(self, validated_data, instance):
         instance = super(CardSerializer, self)._postsave(validated_data, instance)
         instance.force_cache_member()
+        instance.force_cache_cameos()
         return instance
 
     class Meta:
@@ -160,7 +161,7 @@ class CardSerializer(MagiSerializer):
             # / Not editable
             'performance_min', 'performance_max', 'performance_trained_max',
             'technique_min', 'technique_max', 'technique_trained_max',
-            'visual_min', 'visual_max', 'visual_trained_max',
+            'visual_min', 'visual_max', 'visual_trained_max', 'cameo_members'
         )
 
 class CardSerializerForEditing(CardSerializer):

--- a/api/views.py
+++ b/api/views.py
@@ -146,7 +146,7 @@ class CardSerializer(MagiSerializer):
     def _postsave(self, validated_data, instance):
         instance = super(CardSerializer, self)._postsave(validated_data, instance)
         instance.update_cache("member")
-        instance.force_cache_cameos()
+        instance.update_cache("cameos")
         return instance
 
     class Meta:

--- a/api/views.py
+++ b/api/views.py
@@ -145,7 +145,7 @@ class CardSerializer(MagiSerializer):
 
     def _postsave(self, validated_data, instance):
         instance = super(CardSerializer, self)._postsave(validated_data, instance)
-        instance.force_cache_member()
+        instance.update_cache("member")
         instance.force_cache_cameos()
         return instance
 

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -163,11 +163,15 @@ class CardForm(AutoForm):
             imageObject.image.save(image.name, image)
             instance.chibis.add(imageObject)
         instance.force_cache_chibis()
+        # members can't cameo in their own cards
+        instance.cameo_members = filter(lambda x: x.id != instance.member_id, self.cleaned_data['cameo_members'])
+        instance.force_cache_cameos()
         return instance
 
     class Meta(AutoForm.Meta):
         model = models.Card
         fields = '__all__'
+        optional_fields = ('cameo_members',)
         save_owner_on_creation = True
 
 def to_translate_card_form_class(cls):
@@ -201,7 +205,20 @@ class CardFilterForm(MagiFiltersForm):
         return queryset.filter(Q(i_skill_type=value) | Q(i_side_skill_type=value))
     i_skill_type_filter = MagiFilter(to_queryset=skill_filter_to_queryset)
 
+    def member_id_to_queryset(self, queryset, request, value):
+        main_member_condition = Q(member_id=value)
+
+        if self.data.get('member_includes_cameos'):
+            return queryset.filter(main_member_condition | Q(_cache_cameos_search_blob__icontains='@{}@'.format(value)))
+        else:
+            return queryset.filter(main_member_condition)
+
     member_id = forms.ChoiceField(choices=BLANK_CHOICE_DASH + [(id, full_name) for (id, full_name, image) in getattr(django_settings, 'FAVORITE_CHARACTERS', [])], initial=None, label=_('Member'))
+    member_id_filter = MagiFilter(to_queryset=member_id_to_queryset)
+
+    member_includes_cameos = forms.BooleanField(label=_('Include cameos'))
+    # used in member_id_to_queryset
+    member_includes_cameos_filter = MagiFilter(noop=True)
 
     member_band = forms.ChoiceField(choices=BLANK_CHOICE_DASH + i_choices(models.Member.BAND_CHOICES), initial=None, label=_('Band'))
     member_band_filter = MagiFilter(selector='member__i_band')
@@ -238,7 +255,7 @@ class CardFilterForm(MagiFiltersForm):
 
     class Meta(MagiFiltersForm.Meta):
         model = models.Card
-        fields = ('view', 'search', 'member_id', 'member_band', 'i_rarity', 'i_attribute', 'origin', 'i_skill_type', 'member_band', 'version', 'ordering', 'reverse_order')
+        fields = ('view', 'search', 'member_id', 'member_includes_cameos', 'member_band', 'i_rarity', 'i_attribute', 'origin', 'i_skill_type', 'member_band', 'version', 'ordering', 'reverse_order')
 
 ############################################################
 # CollectibleCard

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -165,7 +165,7 @@ class CardForm(AutoForm):
         instance.force_cache_chibis()
         # members can't cameo in their own cards
         instance.cameo_members = filter(lambda x: x.id != instance.member_id, self.cleaned_data['cameo_members'])
-        instance.force_cache_cameos()
+        instance.update_cache('cameos')
         return instance
 
     class Meta(AutoForm.Meta):

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -206,12 +206,10 @@ class CardFilterForm(MagiFiltersForm):
     i_skill_type_filter = MagiFilter(to_queryset=skill_filter_to_queryset)
 
     def member_id_to_queryset(self, queryset, request, value):
-        main_member_condition = Q(member_id=value)
-
         if self.data.get('member_includes_cameos'):
-            return queryset.filter(main_member_condition | Q(_cache_cameos_search_blob__icontains='@{}@'.format(value)))
+            return queryset.filter(Q(member_id=value) | Q(cameo_members__id=value))
         else:
-            return queryset.filter(main_member_condition)
+            return queryset.filter(member_id=value)
 
     member_id = forms.ChoiceField(choices=BLANK_CHOICE_DASH + [(id, full_name) for (id, full_name, image) in getattr(django_settings, 'FAVORITE_CHARACTERS', [])], initial=None, label=_('Member'))
     member_id_filter = MagiFilter(to_queryset=member_id_to_queryset)

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -592,6 +592,19 @@ class CardCollection(MagiCollection):
                         'verbose_name': _('Chibi'),
                     } for chibi in item.cached_chibis],
                 }))
+            
+            if item.cached_cameos:
+                extra_fields.append(('cameo_members', {
+                    'icon': 'users',
+                    'verbose_name': _('Other characters in this card'),
+                    'type': 'images_links',
+                    'images': [{
+                        'value': cameo.s_image_url,
+                        'link': cameo.link,
+                        'ajax_link': cameo.ajax_link,
+                        'link_text': cameo.name,
+                    } for cameo in item.cached_cameos]
+                }))
 
             # Exclude fields
             if exclude_fields == 1:

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -435,7 +435,7 @@ CARDS_ICONS = {
 }
 
 CARDS_ORDER = [
-    'id', 'card_name', 'member', 'rarity', 'attribute', 'versions', 'is_promo', 'release_date',
+    'id', 'card_name', 'member', 'cameo_members', 'rarity', 'attribute', 'versions', 'is_promo', 'release_date',
     'japanese_skill_name', 'skill_type', 'japanese_skill',
     'gacha', 'images', 'arts', 'transparents',
 ]
@@ -596,7 +596,7 @@ class CardCollection(MagiCollection):
             if item.cached_cameos:
                 extra_fields.append(('cameo_members', {
                     'icon': 'users',
-                    'verbose_name': _('Other characters in this card'),
+                    'verbose_name': _('Other members in this card'),
                     'type': 'images_links',
                     'images': [{
                         'value': cameo.s_image_url,

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -596,12 +596,12 @@ class CardCollection(MagiCollection):
             if item.cached_cameos:
                 extra_fields.append(('cameo_members', {
                     'icon': 'users',
-                    'verbose_name': _('Other members in this card'),
+                    'verbose_name': _('Cameos'),
                     'type': 'images_links',
                     'images': [{
-                        'value': cameo.s_image_url,
-                        'link': cameo.link,
-                        'ajax_link': cameo.ajax_link,
+                        'value': cameo.image_url,
+                        'link': cameo.item_url,
+                        'ajax_link': cameo.ajax_item_url,
                         'link_text': cameo.name,
                     } for cameo in item.cached_cameos]
                 }))

--- a/bang/migrations/0032_card_cameo_members.py
+++ b/bang/migrations/0032_card_cameo_members.py
@@ -14,18 +14,18 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='card',
             name='cameo_members',
-            field=models.ManyToManyField(related_name='cameo_members', verbose_name='Other members in this card', to='bang.Member'),
+            field=models.ManyToManyField(related_name='cameo_members', verbose_name='Cameos', to='bang.Member'),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='card',
-            name='_cache_cameos_blob',
-            field=models.TextField(null=True),
+            name='_cache_cameos_last_update',
+            field=models.DateTimeField(null=True),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='card',
-            name='_cache_cameos_search_blob',
+            name='_cache_j_cameos',
             field=models.TextField(null=True),
             preserve_default=True,
         ),

--- a/bang/migrations/0032_card_cameo_members.py
+++ b/bang/migrations/0032_card_cameo_members.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('bang', '0031_eventparticipation_screenshot'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='card',
+            name='cameo_members',
+            field=models.ManyToManyField(related_name='cameo_members', verbose_name='Other characters in this card', to='bang.Member'),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='card',
+            name='_cache_cameos_blob',
+            field=models.TextField(null=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='card',
+            name='_cache_cameos_search_blob',
+            field=models.TextField(null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/bang/migrations/0032_card_cameo_members.py
+++ b/bang/migrations/0032_card_cameo_members.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='card',
             name='cameo_members',
-            field=models.ManyToManyField(related_name='cameo_members', verbose_name='Other characters in this card', to='bang.Member'),
+            field=models.ManyToManyField(related_name='cameo_members', verbose_name='Other members in this card', to='bang.Member'),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/bang/models.py
+++ b/bang/models.py
@@ -531,6 +531,9 @@ class Card(MagiModel):
 
     chibis = models.ManyToManyField(Image, related_name="chibi", verbose_name=_('Chibi'))
 
+    # Other members that appear in the card art
+    cameo_members = models.ManyToManyField(Member, related_name='cameo_members', verbose_name=_('Cameos'))
+
     # Tools
 
     TRAINABLE_RARITIES = [3, 4]
@@ -692,22 +695,18 @@ class Card(MagiModel):
             'http_image_url': get_http_image_url_from_path(path),
         }) for id, path in zip(split_data(self._cache_chibis_ids), split_data(self._cache_chibis_paths))]
 
-    cameo_members = models.ManyToManyField(Member, related_name='cameo_members', verbose_name=_('Cameos'))
-
     _cached_cameos_collection_name = 'member'
     _cache_cameos_days = 200
     _cache_cameos_last_update = models.DateTimeField(null=True)
     _cache_j_cameos = models.TextField(null=True)
 
     def to_cache_cameos(self):
-        them = self.cameo_members.all()
-
         return [{
             'id': cameo.id,
             'name': unicode(cameo.name),
             'japanese_name': unicode(cameo.japanese_name),
             'image': unicode(cameo.square_image),
-        } for cameo in them]
+        } for cameo in self.cameo_members.all()]
     
     @classmethod
     def cached_cameos_pre(self, d):

--- a/bang/models.py
+++ b/bang/models.py
@@ -13,7 +13,6 @@ from magi.abstract_models import AccountAsOwnerModel, BaseAccount
 from magi.item_model import BaseMagiModel, MagiModel, get_image_url_from_path, get_http_image_url_from_path, i_choices, getInfoFromChoices
 from magi.utils import AttrDict, tourldash, split_data, join_data, uploadToKeepName, staticImageURL
 from bang.django_translated import t
-import json
 
 ############################################################
 # Utility Models

--- a/bang/models.py
+++ b/bang/models.py
@@ -710,7 +710,7 @@ class Card(MagiModel):
             )
         return u''
     
-    cameo_members = models.ManyToManyField(Member, related_name='cameo_members', verbose_name=_('Other characters in this card'))
+    cameo_members = models.ManyToManyField(Member, related_name='cameo_members', verbose_name=_('Other members in this card'))
     _cache_cameos_blob = models.TextField(null=True)
     _cache_cameos_search_blob = models.TextField(null=True)
 


### PR DESCRIPTION
Summary:

- adds a list of members who appear in the card but aren't the main member to card pages (the links in the list currently just go to the member page)
- adds new field `cameo_members` to the API, listing member ids who appear in the card art
- adds a cameo selector to the card edit form
- adds a checkbox under the member filter that will also include cards the filtered member cameos in

The cameo search is implemented by full text searching a cache field which feels a bit weird, but it was the simplest way I thought of doing it. 