### PR TITLE
Allow Event.secondary_card to be 3*

### DIFF
--- a/bang/forms.py
+++ b/bang/forms.py
@@ -335,18 +335,18 @@ class EventForm(AutoForm):
         if 'c_versions' in self.fields:
             del(self.fields['c_versions'])
 
-    def _clean_card_rarity(self, field_name, rarity):
+    def _clean_card_rarity(self, field_name, rarities):
         if field_name in self.cleaned_data and self.cleaned_data[field_name]:
-            if self.cleaned_data[field_name].i_rarity != rarity:
-                raise forms.ValidationError(u'Rarity must be {}'.format(rarity))
+            if self.cleaned_data[field_name].i_rarity not in rarities:
+                raise forms.ValidationError(u'Rarity must be one of {}'.format(tuple(rarities)))
             return self.cleaned_data[field_name]
         return None
 
     def clean_main_card(self):
-        return self._clean_card_rarity('main_card', 3)
+        return self._clean_card_rarity('main_card', {3})
 
     def clean_secondary_card(self):
-        return self._clean_card_rarity('secondary_card', 2)
+        return self._clean_card_rarity('secondary_card', {3, 2})
 
     def save(self, commit=False):
         instance = super(EventForm, self).save(commit=False)

--- a/bang/models.py
+++ b/bang/models.py
@@ -883,7 +883,8 @@ class Event(MagiModel):
         'i_rarity': 3,
     }, on_delete=models.SET_NULL)
     secondary_card = models.ForeignKey(Card, related_name='secondary_card_event', null=True, limit_choices_to={
-        'i_rarity': 2,
+        'i_rarity__lte': 3,
+        'i_rarity__gt': 1,
     }, on_delete=models.SET_NULL)
 
     BOOST_ATTRIBUTE_CHOICES = Card.ATTRIBUTE_CHOICES


### PR DESCRIPTION
Just for Aya from the backstage pass event. This doesn't need any db migrations.