### PR TITLE
Sort favourite character list by ID

### DIFF
--- a/bang/management/commands/generate_settings.py
+++ b/bang/management/commands/generate_settings.py
@@ -42,7 +42,7 @@ def generate_settings():
         translation_activate(old_lang)
 
     print 'Get the characters'
-    all_members = models.Member.objects.all().order_by('name')
+    all_members = models.Member.objects.all().order_by('id')
     favorite_characters = [(
         member.pk,
         member.name,


### PR DESCRIPTION
And by ID, I mean band/instrument as given by the ordering of internal character IDs (see #14). 

This affects everything that uses the list:
- Member filter on /cards/
- Choosing your top 3 girls on profile settings
- Boost member filter on /events/ (after #96)

#95 makes the same change but for the actual /members/ page.