### PR TITLE
Live2d viewer

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -7,6 +7,10 @@ from bang import models
 ############################################################
 # Fields
 
+class FileField(serializers.FileField):
+    def to_representation(self, value):
+        return get_http_image_url_from_path(value)
+
 class ImageField(serializers.ImageField):
     def to_representation(self, value):
         return get_http_image_url_from_path(value)
@@ -186,11 +190,13 @@ class CardSerializer(MagiSerializer):
 class CardSerializerForEditing(CardSerializer):
     i_skill_special = IField(models.Card, 'skill_special', required=False)
     i_skill_note_type = IField(models.Card, 'skill_note_type', required=False)
+    live2d_model_pkg = FileField(required=False)
 
     class Meta(CardSerializer.Meta):
         fields = CardSerializer.Meta.fields + (
             'i_skill_special',
             'i_skill_note_type', 'skill_stamina', 'skill_duration', 'skill_percentage', 'skill_alt_percentage',
+            'live2d_model_pkg'
         )
 
 class CardViewSet(viewsets.ModelViewSet):

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -644,9 +644,8 @@ class CardCollection(MagiCollection):
                 # "2" to work around a magicircles bug
                 extra_fields.append(('live2d_model_pkg2', {
                     'verbose_name': 'Live2D',
-                    'type': 'link',
+                    'type': 'button',
                     'value': "/live2d/{}/".format(item.id),
-                    'classes': self.item_buttons_classes,
                     'ajax_link': "/ajax/live2d_ajax/{}/".format(item.id),
                     'link_text': _("View model"),
                     'icon': 'pictures',

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -470,7 +470,7 @@ CARDS_ORDER = [
     'id', 'card_name', 'member', 'cameo_members', 'rarity', 'attribute', 'versions', 'is_promo', 'is_original',
     'release_date',
     'japanese_skill_name', 'skill_type', 'japanese_skill',
-    'gacha', 'images', 'arts', 'transparents',
+    'gacha', 'images', 'arts', 'transparents', 'live2d_model_pkg2'
 ]
 
 CARDS_EXCLUDE = [
@@ -481,6 +481,7 @@ CARDS_EXCLUDE = [
     'visual_min', 'visual_max', 'visual_trained_max',
     'i_skill_note_type', 'skill_stamina', 'skill_duration',
     'skill_percentage', 'skill_alt_percentage', 'i_skill_special',
+    'live2d_model_pkg'
 ]
 
 class CardCollection(MagiCollection):
@@ -637,6 +638,18 @@ class CardCollection(MagiCollection):
                         'ajax_link': cameo.ajax_item_url,
                         'link_text': cameo.name,
                     } for cameo in item.cached_cameos]
+                }))
+            
+            if item.live2d_model_pkg:
+                # "2" to work around a magicircles bug
+                extra_fields.append(('live2d_model_pkg2', {
+                    'verbose_name': 'Live2D',
+                    'type': 'link',
+                    'value': "/live2d/{}/".format(item.id),
+                    'classes': self.item_buttons_classes,
+                    'ajax_link': "/ajax/live2d_ajax/{}/".format(item.id),
+                    'link_text': _("View model"),
+                    'icon': 'pictures',
                 }))
 
             # Exclude fields

--- a/bang/models.py
+++ b/bang/models.py
@@ -520,6 +520,9 @@ class Card(MagiModel):
     transparent = models.ImageField(_('Transparent'), upload_to=uploadItem('c/transparent'), null=True)
     transparent_trained = models.ImageField(string_concat(_('Transparent'), ' (', _('Trained'), ')'), upload_to=uploadItem('c/transparent/a'), null=True)
 
+    # Live2D
+    live2d_model_pkg = models.FileField(_('Live2D'), upload_to=uploadItem('c/l2d'), null=True)
+
     # Statistics
     performance_min = models.PositiveIntegerField(string_concat(_('Performance'), ' (', _('Minimum'), ')'), default=0)
     performance_max = models.PositiveIntegerField(string_concat(_('Performance'), ' (', _('Maximum'), ')'), default=0)

--- a/bang/settings.py
+++ b/bang/settings.py
@@ -128,6 +128,21 @@ ENABLED_PAGES['teambuilder'] = {
     #'navbar_link_list': 'girlsbandparty',
 }
 
+ENABLED_PAGES['live2d'] = {
+    'title': _('Live2D'),
+    'icon': 'settings',
+    'navbar_link': False,
+    'url_variables': [('pk', '\d+'), ('slug', '[^/]*')]
+}
+ENABLED_PAGES['live2d_ajax'] = {
+    'title': _('Live2D'),
+    'icon': 'settings',
+    'navbar_link': False,
+    'ajax': True,
+    'url_variables': [('pk', '\d+')]
+}
+
+
 ENABLED_NAVBAR_LISTS = DEFAULT_ENABLED_NAVBAR_LISTS
 ENABLED_NAVBAR_LISTS['bangdream'] = {
     'title': _('BanG Dream!'),

--- a/bang/templates/pages/live2dajax.html
+++ b/bang/templates/pages/live2dajax.html
@@ -26,19 +26,25 @@
                 loader.parentNode.removeChild(loader);
             }
         });
-    }
 
-    ZipLoaderEarlyInit('{{ static_url }}/js/l2d');
-    // Wait for canvas to be visible before initting DL, otherwise it breaks
-    $("#freeModal").one("shown.bs.modal", function() {
-        actualDLInit();
         $("#freeModal").one("hide.bs.modal", function() {
             // Bug: the DirectorLite object is leaked because we don't unbind the canvas event handlers.
             // Live2D objects are properly dealloced, so this is ok for now...
             window.DL.terminate();
             delete window.DL;
         });
-    });
+    }
+
+    ZipLoaderEarlyInit('{{ static_url }}/js/l2d');
+    // Wait for canvas to be visible before initting DL, otherwise it breaks
+    if ($("#freeModal").hasClass("in")) {
+        // Sometimes it's already on screen, so shown.bs.modal doesn't fire again
+        actualDLInit();
+    } else {
+        $("#freeModal").one("shown.bs.modal", function() {
+            actualDLInit();
+        });
+    }
 </script>
 {% endblock %}
 

--- a/bang/templates/pages/live2dajax.html
+++ b/bang/templates/pages/live2dajax.html
@@ -1,0 +1,56 @@
+{% extends "ajax.html" %}
+{% load tools %}
+
+{# Be careful. This file is subtly different from live2dviewer.html. #}
+
+{% block afterjs %}
+<script>
+    function actualDLInit() {
+        var pkg = '{{ package_url }}';
+        window.DL = new DirectorLite({
+            canvasName: "dltarget",
+            controlName: "dlcontrols",
+            withPackageAtURL: pkg,
+            mountedToLocation: "banpa",
+            usingInitialModelName: "banpa:director.model.json",
+            callbackOnFirstModelLoaded: function() {
+                var loader = document.getElementById("loadingMessage");
+                loader.parentNode.removeChild(loader);
+            },
+        });
+    }
+
+    ZipLoaderEarlyInit('{{ static_url }}/js/l2d');
+    // Wait for canvas to be visible before initting DL, otherwise it breaks
+    $("#freeModal").one("shown.bs.modal", function() {
+        actualDLInit();
+        $("#freeModal").one("hide.bs.modal", function() {
+            // Bug: the DirectorLite object is leaked because we don't unbind the canvas event handlers.
+            // Live2D objects are properly dealloced, so this is ok for now...
+            window.DL.terminate();
+            delete window.DL;
+        });
+    });
+</script>
+{% endblock %}
+
+{% block content %}
+<div id="dlcontainer" style="position:relative">
+    <p id="loadingMessage" class="alert alert-warning">Please wait while I load the Live2D model...</p>
+    <canvas id="dltarget" width="562" height="800" style="max-width:562px; width:100%; height:100%; margin:0 auto; image-rendering: pixelated"></canvas>
+
+    <div id="dlcontrols" style="display: none; position: absolute; top: 0; left: 0;">
+        <div id="dltemplate" style="display: none">
+            <i class="flaticon-star"></i> <label class="dlname"></label> <br>
+            <label>Action: </label>
+            <select class="dlmotions"></select><br>
+
+            <label>Expression: </label>
+            <select class="dlexpressions"></select>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+
+

--- a/bang/templates/pages/live2dajax.html
+++ b/bang/templates/pages/live2dajax.html
@@ -1,5 +1,6 @@
 {% extends "ajax.html" %}
 {% load tools %}
+{% load i18n %}
 
 {# Be careful. This file is subtly different from live2dviewer.html. #}
 
@@ -13,10 +14,17 @@
             withPackageAtURL: pkg,
             mountedToLocation: "banpa",
             usingInitialModelName: "banpa:director.model.json",
+            autoResize: true,
             callbackOnFirstModelLoaded: function() {
                 var loader = document.getElementById("loadingMessage");
                 loader.parentNode.removeChild(loader);
             },
+            callbackOnInitFailure: function(code) {
+                var errorHTML = document.getElementById("noWebGLMessage");
+                errorHTML.style.display = null;
+                var loader = document.getElementById("loadingMessage");
+                loader.parentNode.removeChild(loader);
+            }
         });
     }
 
@@ -35,18 +43,47 @@
 {% endblock %}
 
 {% block content %}
-<div id="dlcontainer" style="position:relative">
-    <p id="loadingMessage" class="alert alert-warning">Please wait while I load the Live2D model...</p>
-    <canvas id="dltarget" width="562" height="800" style="max-width:562px; width:100%; height:100%; margin:0 auto; image-rendering: pixelated"></canvas>
+<div id="dlcontainer" style="position:relative; text-align:center">
+    <p id="noWebGLMessage" class="alert alert-danger" style="text-align: left; display:none;">{% trans "Sorry, a browser that supports WebGL is required to view Live2D models." %}</p>
+    <p id="loadingMessage" class="alert alert-warning" style="text-align: left">{% trans "Loading Live2D model. Please wait..." %}</p>
+    <canvas id="dltarget" width="562" height="800" style="max-width:100%; max-height:100%; margin:0 auto"></canvas>
 
-    <div id="dlcontrols" style="display: none; position: absolute; top: 0; left: 0;">
-        <div id="dltemplate" style="display: none">
-            <i class="flaticon-star"></i> <label class="dlname"></label> <br>
-            <label>Action: </label>
-            <select class="dlmotions"></select><br>
+    <div id="dlcontrols" class="dlhidden" style="display: none;">
+        <button class="btn btn-secondary btn-sm" title="Controls" onclick="DLToggleControls(event)"><i class="flaticon flaticon-settings"></i></button>
 
-            <label>Expression: </label>
-            <select class="dlexpressions"></select>
+        <div id="dltemplate" style="display: none;">
+            <i class="flaticon-about"></i> <label>{% trans "Model" context "BanPa model viewer" %}: </label> <span class="dlname"></span>
+
+            <div>
+                {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                <label>{% trans "Breathe" context "BanPa model viewer" %}: </label>
+                <input type="checkbox" class="dlbreathe" checked />
+                {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                <label>{% trans "Blink" context "BanPa model viewer" %}: </label>
+                <input type="checkbox" class="dlblink" checked />
+                {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                <label>{% trans "Sway" context "BanPa model viewer" %}: </label>
+                <input type="checkbox" class="dlvariance" checked />
+            </div>
+
+            <div>
+                {# Translators: Label for a list of choices. Limited space, so please try to keep it short. #}
+                <label>{% trans "Action" context "BanPa model viewer" %}: </label>
+                <select class="dlmotions"></select>
+                {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                <label>{% trans "Loop" context "BanPa model viewer" %}: </label>
+                <input type="checkbox" class="dlloopmotions" />
+            </div>
+
+            <div>
+                {# Translators: Label for a list of choices. Limited space, so please try to keep it short. #}
+                <label>{% trans "Expression" context "BanPa model viewer" %}: </label>
+                <select class="dlexpressions"></select>
+            </div>
+
+            <div>
+                <button class="dltoggleupdates btn btn-secondary btn-sm" data-string-pause="{% trans "Pause" context "BanPa model viewer" %}" data-string-unpause="{% trans "Unpause" context "BanPa model viewer" %}">{% trans "Pause" context "BanPa model viewer" %}</button>
+            </div>
         </div>
     </div>
 </div>

--- a/bang/templates/pages/live2dajax.html
+++ b/bang/templates/pages/live2dajax.html
@@ -83,9 +83,13 @@
 
             <div>
                 <button class="dltoggleupdates btn btn-secondary btn-sm" data-string-pause="{% trans "Pause" context "BanPa model viewer" %}" data-string-unpause="{% trans "Unpause" context "BanPa model viewer" %}">{% trans "Pause" context "BanPa model viewer" %}</button>
+                <button class="dlscreenshot btn btn-secondary btn-sm">{% trans "Screenshot" context "BanPa model viewer" %}</button>
+                {# Translators: Button label. This is supposed to be a continuation of "Screenshot". #}
+                <button class="dlscreenshotbg btn btn-secondary btn-sm">{% trans "(with background)" context "BanPa model viewer" %}</button>
             </div>
         </div>
     </div>
+    <img id="secretBackgroundForScreenshots" src="{{ static_url }}img/bg_live2d_viewer.png" style="display: none;" />
 </div>
 {% endblock %}
 

--- a/bang/templates/pages/live2dviewer.html
+++ b/bang/templates/pages/live2dviewer.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load tools %}
+{% load i18n %}
 
 {% block afterjs %}
 <script>
@@ -16,6 +17,12 @@
                 var loader = document.getElementById("loadingMessage");
                 loader.parentNode.removeChild(loader);
             },
+            callbackOnInitFailure: function(code) {
+                var errorHTML = document.getElementById("noWebGLMessage");
+                errorHTML.style.display = null;
+                var loader = document.getElementById("loadingMessage");
+                loader.parentNode.removeChild(loader);
+            }
         });
     }
 
@@ -26,18 +33,47 @@
 
 {% block content %}
 <div class="container item-container">
-    <div id="dlcontainer" style="padding-top:32px; position:relative;">
-        <p id="loadingMessage" class="alert alert-warning">Please wait while I load the Live2D model...</p>
-        <canvas id="dltarget" width="1334" height="1000" style="max-width:100%; max-height:100%; margin: 0 auto; image-rendering: pixelated"></canvas>
+    <div id="dlcontainer" style="padding-top:32px; position:relative; text-align:center">
+        <p id="noWebGLMessage" class="alert alert-danger" style="text-align: left; display:none;">{% trans "Sorry, a browser that supports WebGL is required to view Live2D models." %}</p>
+        <p id="loadingMessage" class="alert alert-warning" style="text-align: left">{% trans "Loading Live2D model. Please wait..." %}</p>
+        <canvas id="dltarget" width="1334" height="1000" style="max-width:100%; max-height:100%;"></canvas>
 
-        <div id="dlcontrols" style="display: none; position: absolute; top: 60px; left: 0;">
-            <div id="dltemplate" style="display: none">
-                <i class="flaticon-star"></i> <label class="dlname"></label> <br>
-                <label>Action: </label>
-                <select class="dlmotions"></select><br>
+        <div id="dlcontrols" class="dlhidden" style="display: none;">
+            <button class="btn btn-secondary btn-sm" title="Controls" onclick="DLToggleControls(event)"><i class="flaticon flaticon-settings"></i></button>
 
-                <label>Expression: </label>
-                <select class="dlexpressions"></select>
+            <div id="dltemplate" style="display: none;">
+                <i class="flaticon-about"></i> <label>{% trans "Model" context "BanPa model viewer" %}: </label> <span class="dlname"></span>
+
+                <div>
+                    {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                    <label>{% trans "Breathe" context "BanPa model viewer" %}: </label>
+                    <input type="checkbox" class="dlbreathe" checked />
+                    {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                    <label>{% trans "Blink" context "BanPa model viewer" %}: </label>
+                    <input type="checkbox" class="dlblink" checked />
+                    {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                    <label>{% trans "Sway" context "BanPa model viewer" %}: </label>
+                    <input type="checkbox" class="dlvariance" checked />
+                </div>
+
+                <div>
+                    {# Translators: Label for a list of choices. Limited space, so please try to keep it short. #}
+                    <label>{% trans "Action" context "BanPa model viewer" %}: </label>
+                    <select class="dlmotions"></select>
+                    {# Translators: Label for a checkbox. Limited space, so please try to keep it short. #}
+                    <label>{% trans "Loop" context "BanPa model viewer" %}: </label>
+                    <input type="checkbox" class="dlloopmotions" />
+                </div>
+
+                <div>
+                    {# Translators: Label for a list of choices. Limited space, so please try to keep it short. #}
+                    <label>{% trans "Expression" context "BanPa model viewer" %}: </label>
+                    <select class="dlexpressions"></select>
+                </div>
+
+                <div>
+                    <button class="dltoggleupdates btn btn-secondary btn-sm" data-string-pause="{% trans "Pause" context "BanPa model viewer" %}" data-string-unpause="{% trans "Unpause" context "BanPa model viewer" %}">{% trans "Pause" context "BanPa model viewer" %}</button>
+                </div>
             </div>
         </div>
     </div>

--- a/bang/templates/pages/live2dviewer.html
+++ b/bang/templates/pages/live2dviewer.html
@@ -73,9 +73,14 @@
 
                 <div>
                     <button class="dltoggleupdates btn btn-secondary btn-sm" data-string-pause="{% trans "Pause" context "BanPa model viewer" %}" data-string-unpause="{% trans "Unpause" context "BanPa model viewer" %}">{% trans "Pause" context "BanPa model viewer" %}</button>
+                    {# Translators: Button label. #}
+                    <button class="dlscreenshot btn btn-secondary btn-sm">{% trans "Screenshot" context "BanPa model viewer" %}</button>
+                    {# Translators: Button label. This is supposed to be a continuation of "Screenshot". #}
+                    <button class="dlscreenshotbg btn btn-secondary btn-sm">{% trans "(with background)" context "BanPa model viewer" %}</button>
                 </div>
             </div>
         </div>
     </div>
+    <img id="secretBackgroundForScreenshots" src="{{ static_url }}img/bg_live2d_viewer.png" style="display: none;" />
 </div>
 {% endblock %}

--- a/bang/templates/pages/live2dviewer.html
+++ b/bang/templates/pages/live2dviewer.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load tools %}
+
+{% block afterjs %}
+<script>
+    function actualDLInit() {
+        var pkg = '{{ package_url }}';
+        window.DL = new DirectorLite({
+            canvasName: "dltarget",
+            controlName: "dlcontrols",
+            withPackageAtURL: pkg,
+            mountedToLocation: "banpa",
+            usingInitialModelName: "banpa:director.model.json",
+            autoResize: true,
+            callbackOnFirstModelLoaded: function() {
+                var loader = document.getElementById("loadingMessage");
+                loader.parentNode.removeChild(loader);
+            },
+        });
+    }
+
+    ZipLoaderEarlyInit('{{ static_url }}/js/l2d');
+    actualDLInit();
+</script>
+{% endblock %}
+
+{% block content %}
+<div class="container item-container">
+    <div id="dlcontainer" style="padding-top:32px; position:relative;">
+        <p id="loadingMessage" class="alert alert-warning">Please wait while I load the Live2D model...</p>
+        <canvas id="dltarget" width="1334" height="1000" style="max-width:100%; max-height:100%; margin: 0 auto; image-rendering: pixelated"></canvas>
+
+        <div id="dlcontrols" style="display: none; position: absolute; top: 60px; left: 0;">
+            <div id="dltemplate" style="display: none">
+                <i class="flaticon-star"></i> <label class="dlname"></label> <br>
+                <label>Action: </label>
+                <select class="dlmotions"></select><br>
+
+                <label>Expression: </label>
+                <select class="dlexpressions"></select>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/bang/views.py
+++ b/bang/views.py
@@ -1,10 +1,48 @@
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import render, redirect
 from django.conf import settings as django_settings
-from magi.utils import getGlobalContext, redirectWhenNotAuthenticated, cuteFormFieldsForContext, CuteFormTransform
+from magi.utils import getGlobalContext, redirectWhenNotAuthenticated, cuteFormFieldsForContext, CuteFormTransform, get_one_object_or_404
+from magi.item_model import get_image_url_from_path
 from magi.views import indexExtraContext
 from bang.magicollections import CardCollection
 from bang.forms import TeamBuilderForm
+from bang.models import Card
+
+LIVE2D_JS_FILES = [
+    "l2d/zip",
+    "l2d/zip-ext",
+    "l2d/z-worker.combo",
+    "l2d/ZipLoader",
+    "l2d/live2d.min",
+    "l2d/Live2DFramework",
+    "l2d/MatrixStack",
+    "l2d/ModelSettingJson",
+    "l2d/LAppModel",
+    "l2d/DirectorLite",
+]
+
+def live2d_ajax(request, pk):
+    context = getGlobalContext(request)
+    queryset = Card.objects.filter(id=pk, live2d_model_pkg__isnull=False)
+    the_card = get_one_object_or_404(queryset)
+
+    context['item'] = the_card
+    context['package_url'] = get_image_url_from_path(the_card.live2d_model_pkg)
+    context['js_files'] = LIVE2D_JS_FILES
+
+    return render(request, 'pages/live2dajax.html', context)
+
+def live2d(request, pk, slug=None):
+    context = getGlobalContext(request)
+    queryset = Card.objects.filter(id=pk, live2d_model_pkg__isnull=False)
+    the_card = get_one_object_or_404(queryset)
+
+    context['page_title'] = u"{}: {}".format(_('Live2D'), unicode(the_card))
+    context['item'] = the_card
+    context['package_url'] = get_image_url_from_path(the_card.live2d_model_pkg)
+    context['js_files'] = LIVE2D_JS_FILES
+
+    return render(request, 'pages/live2dviewer.html', context)
 
 def teambuilder(request):
     context = getGlobalContext(request)

--- a/bang/views.py
+++ b/bang/views.py
@@ -37,7 +37,7 @@ def live2d(request, pk, slug=None):
     queryset = Card.objects.filter(id=pk, live2d_model_pkg__isnull=False)
     the_card = get_one_object_or_404(queryset)
 
-    context['page_title'] = u"{}: {}".format(_('Live2D'), unicode(the_card))
+    context['page_title'] = u"{}: {}".format('Live2D', unicode(the_card))
     context['item'] = the_card
     context['package_url'] = get_image_url_from_path(the_card.live2d_model_pkg)
     context['js_files'] = LIVE2D_JS_FILES


### PR DESCRIPTION
And this is the server side code for the live2d viewer. Depends on MagiCircles/BanGDream-Static#1.

Currently this just adds a field to the Card model for a live2d zip, and two pages for the standalone and ajax viewers. ~~We still need to add the ability to upload zips through the API, and some touchups for the ajax stuff, but I'm putting this up for early review since I'd like to have it ready in time for leaks tomorrow.~~ This is done now.

The viewer works pretty well in Chrome, Firefox, Safari desktop, and iOS 11.2. Unfortunately I didn't have an android phone to try it with.

Some test files:
[tomoe.zip](https://github.com/MagiCircles/BanGDream/files/1987614/tomoe.zip)
[ako.zip](https://github.com/MagiCircles/BanGDream/files/1987616/ako.zip)

Closes #24