### PR TITLE
Difficulty based ordering field fix

### DIFF
--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -1943,14 +1943,14 @@ class SongCollection(MagiCollection):
                 diff_value = ''
                 diff = getattr(item, u'{}_difficulty'.format(difficulty), None)
                 if diff is not None:
-                    diff_value = mark_safe(u'{}<br />'.format(generateDifficulty(diff)))
+                    diff_value = u'{}<br />'.format(generateDifficulty(diff))
                 if getattr(item, u'{}_notes'.format(difficulty), None) is not None:
-                    diff_value+=_(u'{} notes').format(getattr(item, u'{}_notes'.format(difficulty), None))
+                    diff_value += _(u'{} notes').format(getattr(item, u'{}_notes'.format(difficulty), None))
                 if diff_value != '':
                     fields[difficulty] = {
                         'verbose_name': verbose_name,
                         'type': 'html',
-                        'value': mark_safe(u'{}'.format(diff_value)),
+                        'value': mark_safe(diff_value),
                         'image': staticImageURL(difficulty, folder='songs', extension='png'),
                     }
 

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -1899,15 +1899,14 @@ class SongCollection(MagiCollection):
         setSubField(fields, 'unlock', key='value', value=item.unlock_sentence)
 
         for difficulty, verbose_name in models.Song.DIFFICULTIES:
-            note_image = staticImageURL('note.png')
-            image = staticImageURL('songs/{difficulty}.png'.format(difficulty=difficulty))            
+            image = staticImageURL(difficulty, folder='songs', extension='png')            
             setSubField(fields, u'{}_notes'.format(difficulty), key='image', value=image)
 
             diff = getattr(item, u'{}_difficulty'.format(difficulty), None)
             if diff is not None:
                 setSubField(fields, u'{}_difficulty'.format(difficulty), key='image', value=image)
                 setSubField(fields, u'{}_difficulty'.format(difficulty), key='type', value='html')
-                setSubField(fields, u'{}_difficulty'.format(difficulty), key='value', value=generateDifficulty(diff, False))
+                setSubField(fields, u'{}_difficulty'.format(difficulty), key='value', value=mark_safe(u'{}<br />'.format(generateDifficulty(diff))))
 
         setSubField(fields, 'event', key='type', value='image_link')
         setSubField(fields, 'event', key='value', value=lambda f: item.event.image_url)
@@ -1944,14 +1943,15 @@ class SongCollection(MagiCollection):
                 diff_value = ''
                 diff = getattr(item, u'{}_difficulty'.format(difficulty), None)
                 if diff is not None:
-                    diff_value = generateDifficulty(diff, True)
-                if getattr(item, u'{}_notes'.format(difficulty), None) != None: diff_value+=_(u'{} notes').format(getattr(item, u'{}_notes'.format(difficulty), None))
+                    diff_value = mark_safe(u'{}<br />'.format(generateDifficulty(diff)))
+                if getattr(item, u'{}_notes'.format(difficulty), None) is not None:
+                    diff_value+=_(u'{} notes').format(getattr(item, u'{}_notes'.format(difficulty), None))
                 if diff_value != '':
                     fields[difficulty] = {
                         'verbose_name': verbose_name,
                         'type': 'html',
-                        'value': diff_value,
-                        'image': staticImageURL('songs/{difficulty}.png'.format(difficulty=difficulty)),
+                        'value': mark_safe(u'{}'.format(diff_value)),
+                        'image': staticImageURL(difficulty, folder='songs', extension='png'),
                     }
 
             if 'played' in fields:

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -1903,22 +1903,17 @@ class SongCollection(MagiCollection):
                 static_url=RAW_CONTEXT['static_url'],
                 difficulty=difficulty,
             )
-            notes = getattr(item, u'{}_notes'.format(difficulty), None)
-            diff = getattr(item, u'{}_difficulty'.format(difficulty), None)
-            if notes != None:
-                setSubField(fields, u'{}_notes'.format(difficulty), key='image',
-                            value=image)
+            diff = getattr(item, u'{}_difficulty'.format(difficulty), None)            
+            setSubField(fields, u'{}_notes'.format(difficulty), key='image', value=image)            
             if diff != None:
-                print diff
-                setSubField(fields, u'{}_difficulty'.format(difficulty), key='image',
-                            value=image)
+                setSubField(fields, u'{}_difficulty'.format(difficulty), key='image', value=image)
                 setSubField(fields, u'{}_difficulty'.format(difficulty), key='type',
                             value='html')
                 setSubField(fields, u'{}_difficulty'.format(difficulty), key='value',
                     value=mark_safe(u'{big_images}{small_images}'.format(diff=diff,
-            big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (diff // 5)),
-            small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (diff % 5)),
-        )))
+                    big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (diff // 5)),
+                    small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (diff % 5)),
+                )))
 
         setSubField(fields, 'event', key='type', value='image_link')
         setSubField(fields, 'event', key='value', value=lambda f: item.event.image_url)
@@ -1954,23 +1949,19 @@ class SongCollection(MagiCollection):
             note_image = u'{}img/note.png'.format(RAW_CONTEXT['static_url'])
             for difficulty, verbose_name in models.Song.DIFFICULTIES:
                 diff_value=''
-                notes = getattr(item, u'{}_notes'.format(difficulty), None)
                 diff = getattr(item, u'{}_difficulty'.format(difficulty), None)
                 if diff != None: diff_value=mark_safe(u'{big_images}{small_images}'.format(diff=diff,
                     big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (diff // 5)),
                     small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (diff % 5)),
                     ))
                 if diff_value != '': diff_value+='<br />'
-                if notes != None: diff_value+=_(u'{} notes').format(notes)
+                if getattr(item, u'{}_notes'.format(difficulty), None) != None: diff_value+=_(u'{} notes').format(getattr(item, u'{}_notes'.format(difficulty), None))
                 if diff_value != '':
                     fields[difficulty] = {
                         'verbose_name': verbose_name,
                         'type': 'html',
                         'value': diff_value,
-                        'image': u'{static_url}img/songs/{difficulty}.png'.format(
-                            static_url=RAW_CONTEXT['static_url'],
-                            difficulty=difficulty,
-                        ),
+                        'image': u'{static_url}img/songs/{difficulty}.png'.format(static_url=RAW_CONTEXT['static_url'], difficulty=difficulty,),
                     }
 
             if 'played' in fields:

--- a/bang/utils.py
+++ b/bang/utils.py
@@ -1,6 +1,7 @@
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, get_language
 from magi.default_settings import RAW_CONTEXT
-from magi.utils import globalContext, toTimeZoneDateTime, toCountDown
+from magi.utils import globalContext, toTimeZoneDateTime, toCountDown, staticImageURL
 from bang import models
 #from bang.model_choices import TRAINABLE_RARITIES
 
@@ -64,6 +65,15 @@ def rarity_to_stars_images(rarity):
         static_url=RAW_CONTEXT['static_url'],
         un='' if rarity in models.Card.TRAINABLE_RARITIES else 'un',
     ) * rarity
+
+def generateDifficulty(difficulty, space):
+    note_image = staticImageURL('note.png')
+    val = mark_safe(u'{big_images}{small_images}'.format(
+    big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (difficulty // 5)),
+    small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (difficulty % 5)),))
+    if space is True:
+        val += '<br />'
+    return val
 
 def add_rerun_buttons(view, buttons, request, item):
     if request.user.is_authenticated() and request.user.hasPermission('manage_main_items'):

--- a/bang/utils.py
+++ b/bang/utils.py
@@ -66,13 +66,12 @@ def rarity_to_stars_images(rarity):
         un='' if rarity in models.Card.TRAINABLE_RARITIES else 'un',
     ) * rarity
 
-def generateDifficulty(difficulty, space):
+def generateDifficulty(difficulty):
     note_image = staticImageURL('note.png')
-    val = mark_safe(u'{big_images}{small_images}'.format(
-    big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (difficulty // 5)),
-    small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (difficulty % 5)),))
-    if space is True:
-        val += '<br />'
+    val = '{big_images}{small_images}'.format(
+        big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (difficulty // 5)),
+        small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (difficulty % 5)),
+    )
     return val
 
 def add_rerun_buttons(view, buttons, request, item):

--- a/bang/utils.py
+++ b/bang/utils.py
@@ -68,11 +68,10 @@ def rarity_to_stars_images(rarity):
 
 def generateDifficulty(difficulty):
     note_image = staticImageURL('note.png')
-    val = '{big_images}{small_images}'.format(
+    return u'{big_images}{small_images}'.format(
         big_images=(u'<img src="{}" class="song-big-note">'.format(note_image) * (difficulty // 5)),
         small_images=(u'<img src="{}" class="song-small-note">'.format(note_image) * (difficulty % 5)),
     )
-    return val
 
 def add_rerun_buttons(view, buttons, request, item):
     if request.user.is_authenticated() and request.user.hasPermission('manage_main_items'):


### PR DESCRIPTION
+ When ordering by a difficulty's difficulty, will see an image to the left & the numbers represented as the note images!
![image](https://user-images.githubusercontent.com/30684769/44248765-586ac900-a1a1-11e8-8cc7-9fae55c3776b.png)
+ Same goes for a difficulty's notes! However, listview will lack the notes suffix
![image](https://user-images.githubusercontent.com/30684769/44248817-a8e22680-a1a1-11e8-9b6b-5e2eff692cef.png)
+ Songs don't require the difficulty to display notes anymore, and vice versa! That means no more None notes, and no more accidental item breaks by one accidental input (hopefully)
![image](https://user-images.githubusercontent.com/30684769/44248867-e5158700-a1a1-11e8-93d2-734c3385f856.png)
close #132 