### PR TITLE
Make Members Collection Show 5️ Per Line

### DIFF
--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -339,6 +339,8 @@ class MemberCollection(MagiCollection):
     class ListView(MagiCollection.ListView):
         item_template = custom_item_template
         filter_form = forms.MemberFilterForm
+        per_line = 5
+        page_size = 25
         default_ordering = 'id'
 
     class AddView(MagiCollection.AddView):

--- a/bang/templates/items/memberItem.html
+++ b/bang/templates/items/memberItem.html
@@ -1,6 +1,6 @@
 {% with member=item %}
 <a href="{{ member.item_url }}" data-ajax-url="{{ member.ajax_item_url }}" data-ajax-title="{{ member }}" class="member">
   <img src="{{ member.image_url }}" alt="{{ member }}">
-  <h2>{{ member }}</h2>
+  <h3>{{ member }}</h3>
 </a>
 {% endwith %}


### PR DESCRIPTION
With the recent-ish update to MagiCircles allowing more obscure per_line choices, we can now show a band per line!

Made page_size 25 for now since it needs to be a factor of 5 & we have 25 girls currently, and made character name size h3 so that it'll all fit on one line!

Static Files: https://github.com/MagiCircles/BanGDream-Static/pull/11