### PR TITLE
Add Mission Live to Events

### DIFF
--- a/bang/models.py
+++ b/bang/models.py
@@ -930,6 +930,7 @@ class Event(MagiModel):
         ('challenge_live', _('Challenge Live')),
         ('vs_live', _('VS Live')),
         ('live_trial', _('Live Trial')),
+        ('mission_live', _('Mission Live')),
     )
     i_type = models.PositiveIntegerField(_('Event type'), choices=i_choices(TYPE_CHOICES), default=0)
 


### PR DESCRIPTION
Pretty straightforward. Just altered Event's TYPE_CHOICES list to add the new event type. Not enough details for any other possible fields or alterations.

Needs to be merged before event starts, which will be in mid-November. Preferably should be merged before the end of this current event (Backstage Method) just in case though.

close #173 