### PR TITLE
Gacha+Asset+User Settings+Card Text

### DIFF
--- a/bang/forms.py
+++ b/bang/forms.py
@@ -1111,7 +1111,8 @@ ASSET_COMICS_VALUE_PER_LANGUAGE = {
 }
 
 class AssetFilterForm(MagiFiltersForm):
-    search_fields = ('name', 'd_names', 'c_tags')
+    search_fields = ('name', 'd_names', 'c_tags', 'source', 'source_link')
+    search_fields_labels = {'source_link': ''}
 
     is_event = forms.NullBooleanField(label=_('Event'))
     is_event_filter = MagiFilter(selector='event__isnull')
@@ -1183,8 +1184,8 @@ class AssetFilterForm(MagiFiltersForm):
         # Remove is event from fields if type can't be linked with events
         if 'event' not in self.fields and 'is_event' in self.fields:
             del(self.fields['is_event'])
-        # Only show is song filter for titles (not even official art)
-        if type and type != 'title' and 'is_song' in self.fields:
+        # Only show is song filter for titles+official art
+        if type and type not in ['title', 'official'] and 'is_song' in self.fields:
             del(self.fields['is_song'])
         # Replace band + member with member_band filter
         if 'i_band' in self.fields and 'members' in self.fields:

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -73,7 +73,6 @@ class UserCollection(_UserCollection):
             first_links, meta_links, links = super(UserCollection.ItemView, self).get_meta_links(user, *args, **kwargs)
             if user.preferences.extra.get('i_favorite_band', None):
                 i_band = user.preferences.extra.get('i_favorite_band')
-                print i_band
                 band = models.Song.get_reverse_i('band', int(user.preferences.extra['i_favorite_band']))
                 meta_links.insert(0, AttrDict({
                     't_type': _('Favorite {thing}').format(thing=_('Band')),

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -72,11 +72,14 @@ class UserCollection(_UserCollection):
         def get_meta_links(self, user, *args, **kwargs):
             first_links, meta_links, links = super(UserCollection.ItemView, self).get_meta_links(user, *args, **kwargs)
             if user.preferences.extra.get('i_favorite_band', None):
+                i_band = user.preferences.extra.get('i_favorite_band')
+                print i_band
                 band = models.Song.get_reverse_i('band', int(user.preferences.extra['i_favorite_band']))
                 meta_links.insert(0, AttrDict({
                     't_type': _('Favorite {thing}').format(thing=_('Band')),
                     'value': band,
                     'image_url': staticImageURL(band, folder='mini_band',  extension='png'),
+                    'url': '/members/?i_band={}'.format(i_band) if int(i_band) < 5 else '/songs/?i_band={}'.format(i_band),
                 }))
             return (first_links, meta_links, links)
 
@@ -1610,11 +1613,13 @@ class GachaCollection(MagiCollection):
             'korean_image': staticImageURL('language/kr.png'),
         }, exclude_fields=exclude_fields, **kwargs)
         if get_language() == 'ja' or unicode(item.t_name) == unicode(item.japanese_name):
-            setSubField(fields, 'name', key='value', value=item.japanese_name)
+            setSubField(fields, 'name', key='value', value=_('{} Gacha').format(
+                item.japanese_name[:-3] if item.japanese_name.endswith(u'ガチャ') else item.japanese_name))
         else:
             setSubField(fields, 'name', key='type', value='title_text')
-            setSubField(fields, 'name', key='title', value=item.t_name)
-            setSubField(fields, 'name', key='value', value=item.japanese_name)
+            setSubField(fields, 'name', key='title', value=_('{} Gacha').format(item.t_name))
+            setSubField(fields, 'name', key='value', value=(
+                item.japanese_name[:-3] if item.japanese_name.endswith(u'ガチャ') else item.japanese_name)+u'ガチャ')
 
         for version, version_details in models.Gacha.VERSIONS.items():
             setSubField(

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -713,29 +713,26 @@ class CardCollection(MagiCollection):
                 'icon': 'id',
             }))
 
-            # Add title field
-            title = item.names.get(
-                language, item.japanese_name
-                if language in settings.LANGUAGES_CANT_SPEAK_ENGLISH else item.name)
-            value = item.japanese_name
-            extra_fields.append(('card_name', {
-                'verbose_name': _('Title'),
-                'icon': 'id',
-                'type': 'title_text' if unicode(title) != unicode(value) else 'text',
-                'title': title,
-                'value': value,
-            }))
+            #Add Title
+            title=item.names.get(language, item.name if language not in settings.LANGUAGES_CANT_SPEAK_ENGLISH else None)
+            value = item.japanese_name if item.japanese_name != None else item.name
+            if value != None:
+                extra_fields.append(('card_name', {
+                    'verbose_name': _('Title'),
+                    'icon': 'id',
+                    'type': 'title_text' if title not in [value, None] else 'text',
+                    'title': title,
+                    'value': value,
+                }))
 
-            # Add skill name
-            if item.t_skill_name or item.japanese_skill_name:
-                title = item.skill_names.get(
-                    language, item.japanese_skill_name
-                    if language in settings.LANGUAGES_CANT_SPEAK_ENGLISH else item.skill_name)
-                value = item.japanese_skill_name
+            #Add Skill Name
+            title=item.skill_names.get(language, item.skill_name if language not in settings.LANGUAGES_CANT_SPEAK_ENGLISH else None)
+            value = item.japanese_skill_name if item.japanese_skill_name != None else item.skill_name
+            if value != None:
                 extra_fields.append(('skill_name', {
                     'verbose_name': _('Skill name'),
                     'icon': 'skill',
-                    'type': 'title_text' if unicode(title) != unicode(value) else 'text',
+                    'type': 'title_text' if title not in [value, None] else 'text',
                     'title': title,
                     'value': value,
                 }))

--- a/bang/management/commands/generate_settings.py
+++ b/bang/management/commands/generate_settings.py
@@ -128,7 +128,14 @@ def generate_settings():
             })
         translation_activate(old_lang)
 
+    # User Profile Backgrounds
     print 'Get the backgrounds'
+    background_choices = models.Asset.objects.filter(
+        i_type=models.Asset.get_i('type', 'background'))
+    background_choices |= models.Asset.objects.filter(
+        i_type=models.Asset.get_i('type', 'official'),
+        c_tags__contains='login')
+    
     backgrounds = [
         {
             'id': background.id,
@@ -136,11 +143,7 @@ def generate_settings():
             'image': background.top_image,
             'name': background.name,
             'd_names': background.names,
-        }
-        for background in models.Asset.objects.filter(
-                i_type=models.Asset.get_i('type', 'background'),
-        ) if background.top_image
-    ]
+        } for background in background_choices if background.top_image]
 
     print 'Get the characters'
     all_members = models.Member.objects.all().order_by('id')

--- a/bang/models.py
+++ b/bang/models.py
@@ -1386,7 +1386,7 @@ class Gacha(MagiModel):
     korean_status = property(lambda _s: _s.get_status(version='KR'))
 
     def __unicode__(self):
-        return self.t_name
+        return _('{} Gacha').format(self.t_name)
 
 ############################################################
 # Rerun gacha event


### PR DESCRIPTION
+ Appends Gacha to the end of Gacha titles! Standardizes the view + checks if ガチャ is already at the end of JP gachas in case we forget to remove it or added it previously
+ Links Favorite Band to either 🇦 Related Members `/members/?i_band={}` OR 🇧 Songs from the Band `/songs/?i_band={}`
+ Adds is_song filter for official art and adds Source + Source Link to search, with adjusted search_field_labels so it'll not end in ... ( close #178 )
+ ⚙ Generates background settings to include Official Art tagged "Login"! Lets users continue to use title screens as bg's w/o storing them in the wrong places ( close #179 )
+ Adjusts card title and skill name to not show **None** just because we're missing one of the two translations! (close #180 )

