### PR TITLE
Replace is_limited filter with gacha_type

### DIFF
--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -579,8 +579,9 @@ CARD_CUTEFORM = {
         'transform': CuteFormTransform.Flaticon,
         'to_cuteform': lambda k, v: CardCollection._origin_to_cuteform[k],
     },
-    'is_limited': {
-        'type': CuteFormType.YesNo,
+    'gacha_type': {
+        'transform': CuteFormTransform.Flaticon,
+        'to_cuteform': lambda k, v: GachaCollection._gacha_type_to_cuteform[k],
     },
 }
 

--- a/bang/models.py
+++ b/bang/models.py
@@ -1365,6 +1365,12 @@ class Gacha(MagiModel):
     }
     FIELDS_PER_VERSION = ['image', 'countdown', 'start_date', 'end_date', 'rerun']
 
+    GACHA_TYPES = [
+        ('permanent', _(u'Permanent')),
+        ('limited', _(u'Limited')),
+        ('dreamfes', 'Dream festival'),
+    ]
+
     VERSIONS = Account.VERSIONS
     VERSIONS_CHOICES = Account.VERSION_CHOICES
     c_versions = models.TextField(_('Server availability'), blank=True, null=True, default='"JP"')


### PR DESCRIPTION
close #168

+ Adds gacha_type filter, which functions similarly to /gacha's type filter
+ Adds GACHA_TYPES to Gacha and called the gacha_type choices from there so we don't create the list twice for no reason
+ Replaces is_limited cuteform with Gacha's gacha_type cuteform since the former isn't needed anymore
+ 🎨 JS for is_limited was switched to work with gacha-type instead (https://github.com/MagiCircles/BanGDream-Static/pull/16)
