### PR TITLE
Require Screenshot For Event Participations Under X Rank

### DIFF
--- a/bang/forms.py
+++ b/bang/forms.py
@@ -549,7 +549,7 @@ def to_EventParticipationForm(cls):
                         thing1=_('Screenshot').lower(), thing2=_('Ranking').lower()), number=models.Event.MAX_RANK_WITHOUT_SS[version] + 1))
             return cleaned_data
 
-        #Note: Check if ranking exists first AND skip all if playground, since they are obv F A K E
+        #Note: Check if ranking exists first and skips if playground to avoid unncessary checks
 
         class Meta(cls.form_class.Meta):
             optional_fields = ('score', 'ranking', 'song_score', 'song_ranking')

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -543,10 +543,10 @@ def to_EventParticipationForm(cls):
             is_playground = getattr(cleaned_data.get('account', None), 'is_playground', False)
             
             # If Rank is under X, Require Screenshot
-            if is_playground==False and screenshot==None and cleaned_data.get('ranking') != None:
+            if is_playground == False and screenshot == None and cleaned_data.get('ranking') != None:
                 if cleaned_data.get('ranking') <= models.Event.MAX_RANK_WITHOUT_SS[version]:
                     raise forms.ValidationError(_('{thing} under {number}').format(thing=_('A {thing1} is required for a {thing2}').format(
-                        thing1=_('Screenshot').lower(), thing2=_('Ranking').lower()), number=models.Event.MAX_RANK_WITHOUT_SS[version]+1))
+                        thing1=_('Screenshot').lower(), thing2=_('Ranking').lower()), number=models.Event.MAX_RANK_WITHOUT_SS[version] + 1))
             return cleaned_data
 
         #Note: Check if ranking exists first AND skip all if playground, since they are obv F A K E
@@ -1128,8 +1128,7 @@ ASSET_COMICS_VALUE_PER_LANGUAGE = {
 }
 
 class AssetFilterForm(MagiFiltersForm):
-    search_fields = ('name', 'd_names', 'c_tags', 'source', 'source_link')
-    search_fields_labels = {'source_link': ''}
+    search_fields = ('name', 'd_names', 'c_tags')
 
     is_event = forms.NullBooleanField(label=_('Event'))
     is_event_filter = MagiFilter(selector='event__isnull')

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -534,6 +534,27 @@ def to_EventParticipationForm(cls):
                     if field in self.fields:
                         del(self.fields[field])
 
+        def clean(self):
+            cleaned_data = super(_EventParticipationForm, self).clean()
+
+            version = getattr(cleaned_data.get('account', None), 'version', 'EN') if self.is_creating else getattr(self.instance.account, 'version', 'EN')
+            screenshot = cleaned_data.get('screenshot', '') if self.is_creating else getattr(self.instance, 'screenshot', '')
+            is_playground = getattr(cleaned_data.get('account', None), 'is_playground', False) if self.is_creating else getattr(self.instance.account, 'is_playground', False)
+            print (cleaned_data.get('ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version] if self.is_creating else getattr(self.instance, 'ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version])
+            print getattr(self.instance, 'ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version]
+            print getattr(self.instance, 'ranking', 0)
+            print models.Event.MAX_RANK_WITHOUT_SS[version]
+            if is_playground==False and screenshot=='':
+                if (cleaned_data.get('ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version] if self.is_creating else getattr(self.instance, 'ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version]):
+                    print 'fueesuccess'
+            # Validation Error ANGERY
+                    raise forms.ValidationError(_('{thing} under {number}').format(thing=_('A {thing1} is required for a {thing2}').format(
+                        thing1=_('Screenshot'), thing2=_('Ranking')), number=models.Event.MAX_RANK_WITHOUT_SS[version]))
+            print 'fueeeck'
+            return cleaned_data
+
+        #Note: Check if ranking exists first AND skip all if playground, since they are obv F A K E
+
         class Meta(cls.form_class.Meta):
             optional_fields = ('score', 'ranking', 'song_score', 'song_ranking')
 
@@ -1111,7 +1132,8 @@ ASSET_COMICS_VALUE_PER_LANGUAGE = {
 }
 
 class AssetFilterForm(MagiFiltersForm):
-    search_fields = ('name', 'd_names', 'c_tags')
+    search_fields = ('name', 'd_names', 'c_tags', 'source', 'source_link')
+    search_fields_labels = {'source_link': ''}
 
     is_event = forms.NullBooleanField(label=_('Event'))
     is_event_filter = MagiFilter(selector='event__isnull')
@@ -1183,8 +1205,8 @@ class AssetFilterForm(MagiFiltersForm):
         # Remove is event from fields if type can't be linked with events
         if 'event' not in self.fields and 'is_event' in self.fields:
             del(self.fields['is_event'])
-        # Only show is song filter for titles (not even official art)
-        if type and type != 'title' and 'is_song' in self.fields:
+        # Only show is song filter for titles+official art
+        if type and type not in ['title', 'official'] and 'is_song' in self.fields:
             del(self.fields['is_song'])
         # Replace band + member with member_band filter
         if 'i_band' in self.fields and 'members' in self.fields:

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -1200,8 +1200,8 @@ class AssetFilterForm(MagiFiltersForm):
         # Remove is event from fields if type can't be linked with events
         if 'event' not in self.fields and 'is_event' in self.fields:
             del(self.fields['is_event'])
-        # Only show is song filter for titles+official art
-        if type and type not in ['title', 'official'] and 'is_song' in self.fields:
+        # Only show is song filter for titles (not even official art)
+        if type and type != 'title' and 'is_song' in self.fields:
             del(self.fields['is_song'])
         # Replace band + member with member_band filter
         if 'i_band' in self.fields and 'members' in self.fields:

--- a/bang/forms.py
+++ b/bang/forms.py
@@ -537,20 +537,16 @@ def to_EventParticipationForm(cls):
         def clean(self):
             cleaned_data = super(_EventParticipationForm, self).clean()
 
-            version = getattr(cleaned_data.get('account', None), 'version', 'EN') if self.is_creating else getattr(self.instance.account, 'version', 'EN')
-            screenshot = cleaned_data.get('screenshot', '') if self.is_creating else getattr(self.instance, 'screenshot', '')
-            is_playground = getattr(cleaned_data.get('account', None), 'is_playground', False) if self.is_creating else getattr(self.instance.account, 'is_playground', False)
-            print (cleaned_data.get('ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version] if self.is_creating else getattr(self.instance, 'ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version])
-            print getattr(self.instance, 'ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version]
-            print getattr(self.instance, 'ranking', 0)
-            print models.Event.MAX_RANK_WITHOUT_SS[version]
-            if is_playground==False and screenshot=='':
-                if (cleaned_data.get('ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version] if self.is_creating else getattr(self.instance, 'ranking', 0) <= models.Event.MAX_RANK_WITHOUT_SS[version]):
-                    print 'fueesuccess'
-            # Validation Error ANGERY
+            # Variables to simplify conditionals
+            version = getattr(cleaned_data.get('account', None), 'version', 'EN')
+            screenshot = cleaned_data.get('screenshot', None)
+            is_playground = getattr(cleaned_data.get('account', None), 'is_playground', False)
+            
+            # If Rank is under X, Require Screenshot
+            if is_playground==False and screenshot==None and cleaned_data.get('ranking') != None:
+                if cleaned_data.get('ranking') <= models.Event.MAX_RANK_WITHOUT_SS[version]:
                     raise forms.ValidationError(_('{thing} under {number}').format(thing=_('A {thing1} is required for a {thing2}').format(
-                        thing1=_('Screenshot'), thing2=_('Ranking')), number=models.Event.MAX_RANK_WITHOUT_SS[version]))
-            print 'fueeeck'
+                        thing1=_('Screenshot').lower(), thing2=_('Ranking').lower()), number=models.Event.MAX_RANK_WITHOUT_SS[version]+1))
             return cleaned_data
 
         #Note: Check if ranking exists first AND skip all if playground, since they are obv F A K E

--- a/bang/models.py
+++ b/bang/models.py
@@ -928,6 +928,13 @@ class Event(MagiModel):
         'KR': ((6, 0), (13, 0)),
     }
     FIELDS_PER_VERSION = ['image', 'countdown', 'start_date', 'end_date', 'leaderboard', 'rerun']
+
+    MAX_RANK_WITHOUT_SS = {
+        'JP': 10000,
+        'EN': 1000,
+        'TW': 100,
+        'KR': 1000,
+    }
     # Assets (stamps, titles) are added dynamically to the js variable because multiple can be present
 
     VERSIONS = Account.VERSIONS
@@ -1386,7 +1393,7 @@ class Gacha(MagiModel):
     korean_status = property(lambda _s: _s.get_status(version='KR'))
 
     def __unicode__(self):
-        return self.t_name
+        return _('{} Gacha').format(self.t_name)
 
 ############################################################
 # Rerun gacha event

--- a/bang/models.py
+++ b/bang/models.py
@@ -1393,7 +1393,7 @@ class Gacha(MagiModel):
     korean_status = property(lambda _s: _s.get_status(version='KR'))
 
     def __unicode__(self):
-        return _('{} Gacha').format(self.t_name)
+        return self.t_name
 
 ############################################################
 # Rerun gacha event


### PR DESCRIPTION
close #105 

+ Creates MAX_RANK_WITHOUT_SS in models
+ Based off ^^^, cleans event participation, and returns a ValidationError if a ranking is below a certain number for that account's version without a SS (defaults to EN for server)

Just used something that made sense to me for the validationerror sent back, but it's easily changable if there's a better pre-existing translation.