### PR TITLE
Remove Playground & Hidden Accounts Leaderboard Rankings

### DIFF
--- a/bang/models.py
+++ b/bang/models.py
@@ -161,7 +161,10 @@ class Account(BaseAccount):
 
     def update_cache_leaderboards(self):
         self._cache_leaderboards_last_update = timezone.now()
-        self._cache_leaderboard = type(self).objects.filter(level__gt=self.level, i_version=self.i_version).values('level').distinct().count() + 1
+        if self.is_hidden_from_leaderboard or self.is_playground:
+            self._cache_leaderboard = None
+        else:
+            self._cache_leaderboard = type(self).objects.filter(level__gt=self.level, i_version=self.i_version).values('level').distinct().count() + 1
 
 ############################################################
 # Members


### PR DESCRIPTION
At Vio's Request: 
![image](https://user-images.githubusercontent.com/30684769/49328911-d5d9ff80-f52c-11e8-814e-6bd2954403e9.png)
If is_hidden_from_leaderboard or is_playground, removes leaderboard ranking

While I thought it'd be a MagiCircles fix, I can't find either of these fields or similar inside the MagiCircles code, so I think we only implemented fake accounts for BanPa? If I'm wrong we should close it and implement in magi instead, but I decided just to do it in BanPa for now since it's rather simple.