### PR TITLE
Live Trial -> Live Goals

### DIFF
--- a/bang/forms.py
+++ b/bang/forms.py
@@ -550,7 +550,7 @@ def to_EventParticipationForm(cls):
                     if field in self.fields:
                         del(self.fields[field])
             if models.Event.get_reverse_i('type', i_type) not in models.Event.TRIAL_MASTER_TYPES:
-                for field in ['is_trial_master_completed', 'is_trial_master_ex_completed']:
+                for field in ['is_goal_master', 'is_ex_goal_master']:
                     if field in self.fields:
                         del(self.fields[field])
 

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -1056,8 +1056,8 @@ EVENT_PARTICIPATIONS_ICONS = {
     'ranking': 'trophy',
     'song_score': 'song',
     'song_ranking': 'trophy',
-    'is_trial_master_completed': 'achievement',
-    'is_trial_master_ex_completed': 'achievement',
+    'is_goal_master': 'achievement',
+    'is_ex_goal_master': 'achievement',
     'screenshot': 'screenshot',
 }
 
@@ -1085,8 +1085,8 @@ def to_EventParticipationCollection(cls):
                 'image_folder': 'language',
                 'transform': CuteFormTransform.ImagePath,
             },
-            'is_trial_master_completed': { 'type': CuteFormType.YesNo, },
-            'is_trial_master_ex_completed': { 'type': CuteFormType.YesNo, },
+            'is_goal_master': { 'type': CuteFormType.YesNo, },
+            'is_ex_goal_master': { 'type': CuteFormType.YesNo, },
         }
 
         def to_fields(self, view, item, *args, **kwargs):

--- a/bang/models.py
+++ b/bang/models.py
@@ -1042,8 +1042,8 @@ class EventParticipation(AccountAsOwnerModel):
     song_score = models.PositiveIntegerField(_('Song score'), null=True)
     song_ranking = models.PositiveIntegerField(_('Song ranking'), null=True)
 
-    is_trial_master_completed = models.NullBooleanField(_('Trial master completed'))
-    is_trial_master_ex_completed = models.NullBooleanField(_('Trial master EX completed'))
+    is_goal_master = models.NullBooleanField(_('Goal Master'))
+    is_ex_goal_master = models.NullBooleanField(_('EX Goal Master'))
 
     _thumbnail_screenshot = models.ImageField(null=True, upload_to=uploadThumb('event_screenshot'))
     screenshot = models.ImageField(_('Screenshot'), upload_to=uploadItem('event_screenshot'), null=True)

--- a/bang/models.py
+++ b/bang/models.py
@@ -918,7 +918,7 @@ class Event(MagiModel):
         ('normal', _('Normal')),
         ('challenge_live', _('Challenge Live')),
         ('vs_live', _('VS Live')),
-        ('live_trial', _('Live Trial')),
+        ('live_goals', _('Live Goals')),
         ('mission_live', _('Mission Live')),
     )
     i_type = models.PositiveIntegerField(_('Event type'), choices=i_choices(TYPE_CHOICES), default=0)
@@ -928,7 +928,7 @@ class Event(MagiModel):
         'vs_live',
     ]
     TRIAL_MASTER_TYPES = [
-        'live_trial',
+        'live_goals',
     ]
 
     start_date = models.DateTimeField(string_concat(_('Japanese version'), ' - ', _('Beginning')), null=True)


### PR DESCRIPTION
Since EN is naming Live Try's "Live Goals", we should make the data match on-site

Should be merged latest by mid-January, so that it's accurate once EN's first Live Goals event hits