### PR TITLE
Goal Master Leaderboard Display Fix

### DIFF
--- a/bang/forms.py
+++ b/bang/forms.py
@@ -549,7 +549,7 @@ def to_EventParticipationForm(cls):
                 for field in ['song_score', 'song_ranking']:
                     if field in self.fields:
                         del(self.fields[field])
-            if models.Event.get_reverse_i('type', i_type) not in models.Event.TRIAL_MASTER_TYPES:
+            if models.Event.get_reverse_i('type', i_type) not in models.Event.GOAL_MASTER_TYPES:
                 for field in ['is_goal_master', 'is_ex_goal_master']:
                     if field in self.fields:
                         del(self.fields[field])

--- a/bang/models.py
+++ b/bang/models.py
@@ -931,7 +931,7 @@ class Event(MagiModel):
         'challenge_live',
         'vs_live',
     ]
-    TRIAL_MASTER_TYPES = [
+    GOAL_MASTER_TYPES = [
         'live_goals',
     ]
 
@@ -1074,20 +1074,20 @@ class EventParticipation(AccountAsOwnerModel):
                 'verbose_name': _('Song ranking'),
                 'value': self.song_ranking,
             }),
-            ('is_trial_master_completed', {
+            ('is_goal_master', {
                 'icon': 'achievement',
-                'verbose_name': _('Trial master completed'),
-                'value': self.is_trial_master_completed,
+                'verbose_name': _('Goal Master'),
+                'value': self.is_goal_master,
             }),
-            ('is_trial_master_ex_completed', {
+            ('is_ex_goal_master', {
                 'icon': 'achievement',
-                'verbose_name': _('Trial master EX completed'),
-                'value': self.is_trial_master_ex_completed,
+                'verbose_name': _('EX Goal Master'),
+                'value': self.is_ex_goal_master,
             }),
         ] if v['value'] and not (
             (k in ['song_score', 'song_ranking'] and self.event.type not in Event.SONG_RANKING_TYPES)
-            and (k in ['is_trial_master_completed', 'is_trial_master_ex_completed']
-                 and self.event.type not in Event.TRIAL_MASTER_TYPES)
+            and (k in ['is_goal_master', 'is_ex_goal_master']
+                 and self.event.type not in Event.GOAL_MASTER_TYPES)
         )]
 
     def to_cache_account(self):


### PR DESCRIPTION
Currently, even if an account does have goal master stuff marked, it will not show on the leaderboard
![image](https://user-images.githubusercontent.com/30684769/49781227-c003d180-fcc6-11e8-8226-df2030d24dea.png)
This is because I didn't realize this piece of code existed when changing Live Try's names to match EN, so I went ahead and adjusted it. When working, the fields will now display like so
![image](https://user-images.githubusercontent.com/30684769/49781264-e32e8100-fcc6-11e8-9a10-15e007d63898.png)

Also changed TRIAL_MASTER_TYPES to GOAL_MASTER_TYPES just to make the naming consistent