### PR TITLE
Activity tag for SnaP! Girls Photo Party

### DIFF
--- a/bang/settings.py
+++ b/bang/settings.py
@@ -162,6 +162,10 @@ ACTIVITY_TAGS = [
         'translation': _('CosParty 2018'),
         'has_permission_to_add': lambda r: datetime.datetime(2018, 10, 10, 0, tzinfo=timezone.utc) < timezone.now() < datetime.datetime(2018, 11, 15, tzinfo=timezone.utc),
     }),
+    ('bandorisnap', {
+        'translation': 'Bandori SnaP!',
+        'has_permission_to_add': lambda r: datetime.datetime(2019, 10, 2, 13, tzinfo=timezone.utc) < timezone.now() < datetime.datetime(2019, 11, 10, tzinfo=timezone.utc),
+    }),
     ('unrelated', lambda: _('Not about {thing}').format(thing=_('BanG Dream!'))),
     ('swearing', _('Swearing')),
     ('nsfw', {


### PR DESCRIPTION
Starts: October 2 1PM UTC
Ends: November 10 12AM UTC