### PR TITLE
"Version-less" Official Art

### DIFF
--- a/bang/forms.py
+++ b/bang/forms.py
@@ -1078,9 +1078,17 @@ def asset_type_to_form(_type):
                     del(self.fields[variable])
             if 'i_type' in self.fields:
                 del(self.fields['i_type'])
-            if 'value' in self.fields and _type == 'comic':
-                self.fields['value'] = forms.ChoiceField(label=_('Comics'), choices=(
-                    BLANK_CHOICE_DASH + ASSET_COMICS_VALUE_PER_LANGUAGE['en']))
+            if 'value' in self.fields:
+                if _type == 'comic':
+                    self.fields['value'] = forms.ChoiceField(label=_('Comics'), choices=(
+                        BLANK_CHOICE_DASH + ASSET_COMICS_VALUE_PER_LANGUAGE['en']))
+                # For CN art, remove incorrect version styling next to images
+                elif _type == 'officialart':
+                    self.fields['value'] = forms.ChoiceField(label='Add Version to Images', 
+                        choices=([('1', 'Yes'), ('0', 'No')]),
+                        help_text="If the art doesn't belong to a server we track, select No.",
+                        initial='1'
+                    )
             # Limit tags per type
             if 'c_tags' in self.fields:
                 if _type == 'background':
@@ -1191,11 +1199,7 @@ class AssetFilterForm(MagiFiltersForm):
 
     def _i_version_to_queryset(self, queryset, request, value):
         prefix = models.Account.VERSIONS_PREFIXES.get(models.Account.get_reverse_i('version', int(value)))
-        return queryset.filter(**{
-            u'{}image__isnull'.format(prefix): False,
-        }).exclude(**{
-            u'{}image'.format(prefix): '',
-        })
+        return queryset.filter(**{u'{}image__isnull'.format(prefix): False}).exclude(**{u'{}image'.format(prefix): ''}).exclude(**{u'value': '0'})
 
     i_version = forms.ChoiceField(label=_('Version'), choices=BLANK_CHOICE_DASH + i_choices(models.Account.VERSION_CHOICES))
     i_version_filter = MagiFilter(to_queryset=_i_version_to_queryset)

--- a/bang/magicollections.py
+++ b/bang/magicollections.py
@@ -2476,21 +2476,31 @@ class AssetCollection(MainItemCollection):
         # Images
         for _version, _info in models.Account.VERSIONS.items():
             if getattr(item, '{}image'.format(_info['prefix'])):
-                extra_fields.append(('{}image'.format(_info['prefix']), {
-                    'image': staticImageURL('language/{}.png'.format(_info['image'])),
-                    'link': getattr(item, '{}image_url'.format(_info['prefix'])),
-                    'link_text': string_concat(_('Image'), ' (', _info['translation'], ')'),
-                    'verbose_name': _('Image'),
-                    'verbose_name_subtitle': _info['translation'],
-                    'value': getattr(item, '{}image_thumbnail_url'.format(_info['prefix'])),
-                    'type': 'image_link',
-                }))
+                # If official art is version-less, generate version-less style
+                if getattr(item, 'type')=='officialart' and getattr(item, 'value')==0:
+                    extra_fields.append(('{}image'.format(_info['prefix']), {
+                        'icon': 'download',
+                        'link': getattr(item, '{}image_url'.format(_info['prefix'])),
+                        'link_text': _('Image'),
+                        'verbose_name': _('Image'),
+                        'value': getattr(item, '{}image_thumbnail_url'.format(_info['prefix'])),
+                        'type': 'image_link',
+                    }))
+                else:
+                    extra_fields.append(('{}image'.format(_info['prefix']), {
+                        'image': staticImageURL('language/{}.png'.format(_info['image'])),
+                        'link': getattr(item, '{}image_url'.format(_info['prefix'])),
+                        'link_text': string_concat(_('Image'), ' (', _info['translation'], ')'),
+                        'verbose_name': _('Image'),
+                        'verbose_name_subtitle': _info['translation'],
+                        'value': getattr(item, '{}image_thumbnail_url'.format(_info['prefix'])),
+                        'type': 'image_link',
+                    }))
 
         # Song + Event
         for _field, _tl in [('song', _('Song')), ('event', _('Event'))]:
             if getattr(item, _field):
                  extra_fields.append((_field, subtitledImageLink(getattr(item, _field), _tl, _field)))
-
 
         fields = super(AssetCollection, self).to_fields(view, item, *args, icons=icons, images={
             'image': staticImageURL('language/ja.png'),

--- a/bang/models.py
+++ b/bang/models.py
@@ -2069,7 +2069,7 @@ class Asset(MagiModel):
         }),
         ('officialart', {
             'translation': _('Official art'),
-            'variables': ['name', 'i_band', 'members', 'song', 'c_tags', 'source', 'source_link'],
+            'variables': ['name', 'i_band', 'members', 'song', 'c_tags', 'source', 'source_link', 'value'],
             'icon': 'pictures',
             'to_unicode': lambda _a: (
                 _a.t_name


### PR DESCRIPTION
Mainy for the recently-added CN art, but applicable elsewhere too.

Similarly to comics, it changes the value field to a Yes/No (1, 0) on whether the asset is "versioned" when an asset is Official Art. Defaults to Yes so that most assets can be left alone for this.

If set to No, selecting any value in the version filter other than null will remove the asset from the results, and in ItemView the images for an asset won't specify a version.